### PR TITLE
#include <string>を追加

### DIFF
--- a/src/ColorScheme.h
+++ b/src/ColorScheme.h
@@ -3,6 +3,7 @@
 
 
 #include "Theme.h"
+#include <string>
 
 
 class CColorScheme


### PR DESCRIPTION
TvtPlay.slnをビルドしたところ、ColorScheme.hの94行と95行で
エラー	C2039	'basic_string': 'std' のメンバーではありません
が発生しました。